### PR TITLE
Added ability for SignalRGroupsService to return groups for a ConnectionID.  

### DIFF
--- a/LAN.Core.Eventing.SignalR/LAN.Core.Eventing.SignalR.csproj
+++ b/LAN.Core.Eventing.SignalR/LAN.Core.Eventing.SignalR.csproj
@@ -69,6 +69,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ThreadSafeStringLookup.cs" />
     <Compile Include="DIHandlerRepository.cs" />
     <Compile Include="ISignalRConnectionLookupService.cs" />
     <Compile Include="ISignalRGroupRegistrar.cs" />

--- a/LAN.Core.Eventing.SignalR/SignalRConnectionLookupService.cs
+++ b/LAN.Core.Eventing.SignalR/SignalRConnectionLookupService.cs
@@ -1,23 +1,22 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 
 namespace LAN.Core.Eventing.SignalR
 {
 	public class SignalRConnectionLookupService : ISignalRConnectionLookupService
 	{
-		protected static ConcurrentDictionary<string, ConnectionLookup> ConnectionLookups { get; private set; }
+		protected static ConcurrentDictionary<string, ThreadSafeStringLookup> ConnectionLookups { get; private set; }
 		static SignalRConnectionLookupService()
 		{
-			ConnectionLookups = new ConcurrentDictionary<string, ConnectionLookup>();
+			ConnectionLookups = new ConcurrentDictionary<string, ThreadSafeStringLookup>();
 			SignalREventHub.UserConnected += SignalREventHubOnUserConnected;
 			SignalREventHub.UserDisconnected += SignalREventHubOnUserDisconnected;
 		}
 
 		private static void SignalREventHubOnUserDisconnected(object sender, SignalRUserDisconnectedEventArgs signalRUserDisconnectedEventArgs)
 		{
-			ConnectionLookup lookup;
+			ThreadSafeStringLookup lookup;
 			if (ConnectionLookups.TryGetValue(signalRUserDisconnectedEventArgs.Principal.Identity.Name, out lookup))
 			{
 				lookup.RemoveConnectionId(signalRUserDisconnectedEventArgs.CorrelationId);
@@ -28,73 +27,15 @@ namespace LAN.Core.Eventing.SignalR
 		{
 			var lookup = ConnectionLookups.GetOrAdd(
 				signalRUserConnectedEventArgs.Principal.Identity.Name,
-				s => new ConnectionLookup());
+				s => new ThreadSafeStringLookup());
 
 			lookup.AddConnectionId(signalRUserConnectedEventArgs.CorrelationId);
 		}
 
 		public IEnumerable<string> GetByIdentityName(string identityName)
 		{
-			ConnectionLookup lookup;
-			return ConnectionLookups.TryGetValue(identityName, out lookup) ? lookup.ConnectionIds.AsEnumerable() : Enumerable.Empty<string>();
-		}
-
-		protected sealed class ConnectionLookup
-		{
-			public ConnectionLookup()
-			{
-				_connectionId = new List<string>();
-				_lock = new object();
-			}
-
-			private readonly object _lock;
-			private readonly List<string> _connectionId;
-			public IEnumerable<string> ConnectionIds
-			{
-				get { return _connectionId.AsEnumerable(); }
-			}
-
-			public void AddConnectionId(string connectionId)
-			{
-				EnterLock();
-				try
-				{
-					if (!this._connectionId.Contains(connectionId))
-					{
-						this._connectionId.Add(connectionId);
-					}
-				}
-				finally
-				{
-					ExitLock();
-				}
-			}
-
-			public void RemoveConnectionId(string connectionId)
-			{
-				EnterLock();
-				try
-				{
-					if (this._connectionId.Contains(connectionId))
-					{
-						this._connectionId.Remove(connectionId);
-					}
-				}
-				finally
-				{
-					ExitLock();
-				}
-			}
-
-			private void EnterLock()
-			{
-				Monitor.Enter(this._lock);
-			}
-
-			private void ExitLock()
-			{
-				Monitor.Exit(this._lock);
-			}
+			ThreadSafeStringLookup lookup;
+			return ConnectionLookups.TryGetValue(identityName, out lookup) ? lookup.Strings.AsEnumerable() : Enumerable.Empty<string>();
 		}
 	}
 }

--- a/LAN.Core.Eventing.SignalR/SignalRGroupService.cs
+++ b/LAN.Core.Eventing.SignalR/SignalRGroupService.cs
@@ -1,19 +1,44 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
 using Microsoft.AspNet.SignalR;
 
 namespace LAN.Core.Eventing.SignalR
 {
-	public class SignalRGroupService : IGroupJoinService, IGroupLeaveService
+	public class SignalRGroupService : IGroupJoinService, IGroupLeaveService, IGroupLookupService
 	{
-		public void JoinToGroup(string groupToJoin, string uniqueId)
+		protected static ConcurrentDictionary<string, ThreadSafeStringLookup> ConnectionLookups { get; private set; }
+
+		public void JoinToGroup(string groupToJoin, string connectionId)
 		{
 			var context = GlobalHost.ConnectionManager.GetHubContext<SignalREventHub>();
-			context.Groups.Add(uniqueId, groupToJoin);
+			context.Groups.Add(connectionId, groupToJoin);
+
+			var lookup = ConnectionLookups.GetOrAdd(
+				connectionId,
+				s => new ThreadSafeStringLookup());
+
+			lookup.AddConnectionId(groupToJoin);
+
 		}
 
-		public void LeaveGroup(string groupToLeave, string uniqueId)
+		public void LeaveGroup(string groupToLeave, string connectionId)
 		{
 			var context = GlobalHost.ConnectionManager.GetHubContext<SignalREventHub>();
-			context.Groups.Remove(uniqueId, groupToLeave);
+			context.Groups.Remove(connectionId, groupToLeave);
+
+			ThreadSafeStringLookup lookup;
+			if (ConnectionLookups.TryGetValue(connectionId, out lookup))
+			{
+				lookup.RemoveConnectionId(connectionId);
+			}
+		}
+
+		public IEnumerable<string> GetSignalRGroupsForConnectionId(string connectionId)
+		{
+			ThreadSafeStringLookup lookup;
+			return ConnectionLookups.TryGetValue(connectionId, out lookup) ? lookup.Strings.AsEnumerable() : Enumerable.Empty<string>();
 		}
 	}
 }

--- a/LAN.Core.Eventing.SignalR/ThreadSafeStringLookup.cs
+++ b/LAN.Core.Eventing.SignalR/ThreadSafeStringLookup.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace LAN.Core.Eventing.SignalR
+{
+	public sealed class ThreadSafeStringLookup
+	{
+		public ThreadSafeStringLookup()
+		{
+			_strings = new List<string>();
+			_lock = new object();
+		}
+
+		private readonly object _lock;
+		private readonly List<string> _strings;
+		public IEnumerable<string> Strings
+		{
+			get { return _strings.AsEnumerable(); }
+		}
+
+		public void AddConnectionId(string connectionId)
+		{
+			EnterLock();
+			try
+			{
+				if (!this._strings.Contains(connectionId))
+				{
+					this._strings.Add(connectionId);
+				}
+			}
+			finally
+			{
+				ExitLock();
+			}
+		}
+
+		public void RemoveConnectionId(string connectionId)
+		{
+			EnterLock();
+			try
+			{
+				if (this._strings.Contains(connectionId))
+				{
+					this._strings.Remove(connectionId);
+				}
+			}
+			finally
+			{
+				ExitLock();
+			}
+		}
+
+		private void EnterLock()
+		{
+			Monitor.Enter(this._lock);
+		}
+
+		private void ExitLock()
+		{
+			Monitor.Exit(this._lock);
+		}
+	}
+}

--- a/LAN.Core.Eventing/IGroupLookupService.cs
+++ b/LAN.Core.Eventing/IGroupLookupService.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Contracts;
+
+namespace LAN.Core.Eventing
+{
+	[ContractClass(typeof (IGroupLookupServiceContract))]
+	public interface IGroupLookupService
+	{
+		IEnumerable<string> GetSignalRGroupsForConnectionId(string connectionId);
+	}
+
+	[ContractClassFor(typeof (IGroupLookupService))]
+	abstract class IGroupLookupServiceContract : IGroupLookupService
+	{
+		public IEnumerable<string> GetSignalRGroupsForConnectionId(string connectionId)
+		{
+			Contract.Requires(connectionId != null);
+			throw new System.NotImplementedException();
+		}
+	}
+}

--- a/LAN.Core.Eventing/LAN.Core.Eventing.csproj
+++ b/LAN.Core.Eventing/LAN.Core.Eventing.csproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <Compile Include="EventName.cs" />
     <Compile Include="HandlerBase.cs" />
+    <Compile Include="IGroupLookupService.cs" />
     <Compile Include="IGroupJoinService.cs" />
     <Compile Include="IGroupLeaveService.cs" />
     <Compile Include="IHandler.cs" />


### PR DESCRIPTION
ConnectionID confusion is one of the trickiest issues to handle with SignalR.  This is especially true when the nature of the application necessitates dynamically creating and deleting connections and groups.

The addition of this code will provide a straight forward way for the consumer to examine the groups for a connection.  This, combined with the already existing ISignalRConnectionLookupService will allow the group state for a user to be full explored.
