### PR TITLE
Added SignalR QueryStrings to the request object

### DIFF
--- a/LAN.Core.Eventing.SignalR/SignalREventHub.cs
+++ b/LAN.Core.Eventing.SignalR/SignalREventHub.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Security.Authentication;
 using System.Threading.Tasks;
 using LAN.Core.DependencyInjection;
@@ -56,6 +57,7 @@ namespace LAN.Core.Eventing.SignalR
 
 				data.Add("correlationId", this.Context.ConnectionId);
 				var deserializedRequest = (RequestBase)data.ToObject(handler.GetRequestType());
+				deserializedRequest.QueryStrings = Context.QueryString.ToDictionary(x => x.Key, x => x.Value);
 
 				if (!handler.IsAuthorized(deserializedRequest, this.Context.User))
 				{

--- a/LAN.Core.Eventing/RequestBase.cs
+++ b/LAN.Core.Eventing/RequestBase.cs
@@ -1,7 +1,10 @@
-﻿namespace LAN.Core.Eventing
+﻿using System.Collections.Generic;
+
+namespace LAN.Core.Eventing
 {
 	public abstract class RequestBase
 	{
 		public string CorrelationId { get; set; }
+		public Dictionary<string, string> QueryStrings { get; set; }
 	}
 }


### PR DESCRIPTION
Added SignalR QueryStrings to the request object.  This will allow querystring data to be accessed from the IsAuthorized Method and the Invoke method in EventProcessors.

This was added in a generic way (using dictionary of string) not specific to SignalR
